### PR TITLE
Match height of all primary nav elements

### DIFF
--- a/third_party/src/default/assets/css/elements/_navigation.sass
+++ b/third_party/src/default/assets/css/elements/_navigation.sass
@@ -64,10 +64,13 @@
 .tsd-navigation.primary
     padding-bottom: 40px
 
-    a
+    a, div
         display: block
-        padding-top: 6px
-        padding-bottom: 6px
+        height: 29px
+        line-height: 29px
+        box-sizing: border-box
+        font-size: 14px
+        padding: 0
 
     a.selected
         font-weight: bold


### PR DESCRIPTION
Currently the primary navigation has different heights for headers and links.
With these changes all elements are equal in height (the current one for links is 29px).