### PR TITLE
Fix side-menu links linking to parent instead of /modules/

### DIFF
--- a/third_party/src/default/assets/js/src/typedoc/components/NavigationAccordion.ts
+++ b/third_party/src/default/assets/js/src/typedoc/components/NavigationAccordion.ts
@@ -114,7 +114,7 @@ function renderSimpleHTMLRecursive(
         href = '../modules/'
       }
       if (window.location.href.indexOf('/modules/') > -1) {
-        href = `../${href}`
+        href = `../modules/${href}`
       }
       if (package) {
         if (key === 'Overview') {


### PR DESCRIPTION
Fixes #40 

Side menu links in `modules` mode before this change were linking to `../_fooModule_.html/`, which translated into `/_fooModule_.html`, while the files were actually hosted at `/modules/_fooModule_.html`. This change appends the needed `modules/` relative path